### PR TITLE
fix input field so prompt isn't partly in the text area

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,8 +33,9 @@
                     <div class="row">
                         <div class="input-field center col s6 m6 l6">
                             <i class="material-icons prefix" id="search-button">search</i>
-                            <input id="icon_prefix" type="text" class="validate movie-input">
-                            <label class="label" for="icon_prefix">Search for a movie...</label>
+               <!--             <input id="icon_prefix" type="text" class="validate movie-input">  -->
+                            <input id="icon_prefix" type="text" class="movie-input" placeholder="Movie name...">
+                            <label class="label" id="label-text" for="icon_prefix">Search for a movie...</label>
                         </div> <!-- end of input field div -->
                         <!-- credit the movie db here; we have to do (text & logo) this if we use their api -->
                         <div class="col s4 m5 l5 right-align tmdbLogo">

--- a/javascript.js
+++ b/javascript.js
@@ -241,7 +241,7 @@ $(".input-field").keypress(function (event) {
 });
 
 
-$(document).on("click", ".movie-btn", (event) => { // A click event on the whole docuement that only triggers if it also hits something with the class movie-btn
+$(document).on("click", ".movie-btn", (event) => { // A click event on the whole document that only triggers if it also hits something with the class movie-btn
     console.log(event.currentTarget);
     var temp = $(event.currentTarget).attr("data-name"); // setting a variable to the data-name of the clicked button
     $(".movie-input").val(temp); // setting the value of the movie input to the similar movie title

--- a/style.css
+++ b/style.css
@@ -123,9 +123,10 @@ a:hover, a:active {
 }
 
 /* keep search icon in the input field */
-#search-button {
+/* #search-button {
     margin-top: -10px;
 }
+*/
 
 /* background color for input field (to differentiate it from space around it) */
 /* .input-field {
@@ -139,7 +140,18 @@ a:hover, a:active {
 .movie-input {
     background-color: rgb(250, 236, 209) !important;
     color: red;
-    height: 2em;
+ /*   height: 2em;  */
+}
+
+/* .label & .input-field keeps the "Search for a movie..." label out of the input box, and makes the text visible (it was gray & hard to see) */
+#label-text {
+    margin-top: -10px;
+    color: black;
+    font-size: 20px;
+}
+
+.input-field {
+    margin-top: 30px;
 }
 
 /* highlight header when hovering to make it obvious it's clickable */
@@ -175,7 +187,8 @@ footer {
     }
 
     /* keep search icon by the input field */
-    #search-button {
+    /* #search-button {
         margin-top: 0;
     }
+    */
  }  /* end of block on smaller screens */


### PR DESCRIPTION
I really liked the input field where the prompt slides out of the input box when text was entered, but I couldn't figure out how to make the text go ALL the way out of the input field.  So I used a different materialize class that wasn't as fancy, but I could get the text to display outside of the box.